### PR TITLE
feat: 複数ドライバーのレポート生成に対応

### DIFF
--- a/driver-data.json
+++ b/driver-data.json
@@ -1,19 +1,42 @@
-{
-  "driverName": "安全 太郎",
-  "officeName": "東京事業所",
-  "reportDate": "2025-08-26",
-  "stats": {
-    "avgViolationRatePct": 8.5,
-    "rank": {
-      "total": 25,
-      "position": 5
-    }
+[
+  {
+    "driverId": "driver-001",
+    "driverName": "安全 二郎",
+    "officeName": "大阪事業所",
+    "reportDate": "2025-08-26",
+    "stats": {
+      "avgViolationRatePct": 8.5,
+      "rank": {
+        "total": 25,
+        "position": 5
+      }
+    },
+    "events": [
+      { "id": 1, "violations": 15, "total": 250 },
+      { "id": 2, "violations": 12, "total": 250 },
+      { "id": 3, "violations": 10, "total": 250 },
+      { "id": 7, "violations": 2, "total": 40 },
+      { "id": 8, "violations": 0, "total": 40 }
+    ]
   },
-  "events": [
-    { "id": 1, "violations": 100, "total": 250 },
-    { "id": 2, "violations": 12, "total": 250 },
-    { "id": 3, "violations": 10, "total": 250 },
-    { "id": 7, "violations": 2, "total": 40 },
-    { "id": 8, "violations": 0, "total": 40 }
-  ]
-}
+  {
+    "driverId": "driver-002",
+    "driverName": "模範 花子",
+    "officeName": "東京事業所",
+    "reportDate": "2025-08-26",
+    "stats": {
+      "avgViolationRatePct": 1.2,
+      "rank": {
+        "total": 25,
+        "position": 1
+      }
+    },
+    "events": [
+      { "id": 1, "violations": 1, "total": 280 },
+      { "id": 2, "violations": 2, "total": 280 },
+      { "id": 3, "violations": 0, "total": 280 },
+      { "id": 7, "violations": 0, "total": 50 },
+      { "id": 8, "violations": 0, "total": 50 }
+    ]
+  }
+]

--- a/public/css/report.css
+++ b/public/css/report.css
@@ -35,6 +35,7 @@ body.print-a4 {
 .sheet{
   display:grid; gap:4mm;
   align-content: start;
+  page-break-after: always;
 }
 
 /* ===== ヘッダー（青帯） ===== */

--- a/server.js
+++ b/server.js
@@ -32,82 +32,84 @@ app.get('/report', (req, res) => {
         return res.status(500).send('Error reading report config');
       }
 
-      const data = JSON.parse(dataRaw);
+      const driversData = JSON.parse(dataRaw);
       const config = JSON.parse(configRaw);
-      
-      const eventMap = data.events.reduce((map, event) => {
-        map[event.id] = event;
-        return map;
-      }, {});
 
-      const finalReportData = {
-        pageTitle: config.pageTitle,
-        officeName: data.officeName,
-        driverName: data.driverName,
-        avgViolationRatePct: data.stats.avgViolationRatePct,
-        rank: data.stats.rank,
-        highlights: [],
-        sections: []
-      };
-      
-      // Generate Highlights
-      for (const kind in config.highlights) {
-        const highlightInfo = config.highlights[kind];
-        const eventData = eventMap[highlightInfo.id];
-        if (eventData) {
-          const rate = Math.round((eventData.violations / eventData.total) * 100);
-          let text = highlightInfo.text_template
-            .replace('%TOTAL%', eventData.total)
-            .replace('%VIOLATIONS%', eventData.violations)
-            .replace('%RATE%', rate);
-          
-          finalReportData.highlights.push({
-            kind: kind,
-            badge: highlightInfo.badge,
-            title: config.itemMap[eventData.id].name,
-            text: text
-          });
-        }
-      }
+      const reports = driversData.map(driverData => {
+        const eventMap = driverData.events.reduce((map, event) => {
+          map[event.id] = event;
+          return map;
+        }, {});
 
-      // Generate Sections
-      const sectionsMap = {};
-      data.events.forEach(event => {
-        const itemInfo = config.itemMap[event.id];
-        if (itemInfo) {
-          if (!sectionsMap[itemInfo.maneuver]) {
-            sectionsMap[itemInfo.maneuver] = {
-              title: itemInfo.maneuver,
-              rows: []
-            };
+        const finalReportData = {
+          pageTitle: config.pageTitle,
+          officeName: driverData.officeName,
+          driverName: driverData.driverName,
+          avgViolationRatePct: driverData.stats.avgViolationRatePct,
+          rank: driverData.stats.rank,
+          highlights: [],
+          sections: []
+        };
+
+        // Generate Highlights
+        for (const kind in config.highlights) {
+          const highlightInfo = config.highlights[kind];
+          const eventData = eventMap[highlightInfo.id];
+          if (eventData) {
+            const rate = Math.round((eventData.violations / eventData.total) * 100);
+            let text = highlightInfo.text_template
+              .replace('%TOTAL%', eventData.total)
+              .replace('%VIOLATIONS%', eventData.violations)
+              .replace('%RATE%', rate);
+            
+            finalReportData.highlights.push({
+              kind: kind,
+              badge: highlightInfo.badge,
+              title: config.itemMap[eventData.id].name,
+              text: text
+            });
           }
-          
-          const rate = Math.round((event.violations / event.total) * 100);
-          let tone = '';
-          if (rate >= 25) tone = 'danger';
-          else if (rate > 0) tone = 'warn';
-          else if (rate === 0) tone = 'good';
-
-          let tag = '';
-          if (tone === 'danger' || tone === 'warn') tag = '!';
-          if (tone === 'good') tag = 'good';
-
-
-          sectionsMap[itemInfo.maneuver].rows.push({
-            no: event.id,
-            name: itemInfo.name,
-            tag: tag,
-            tone: tone,
-            rate: rate,
-            detail: `(${event.violations}回/${event.total}回)`,
-            count: event.violations,
-            page: itemInfo.page
-          });
         }
-      });
-      finalReportData.sections = Object.values(sectionsMap);
 
-      res.render('pages/report', finalReportData);
+        // Generate Sections
+        const sectionsMap = {};
+        driverData.events.forEach(event => {
+          const itemInfo = config.itemMap[event.id];
+          if (itemInfo) {
+            if (!sectionsMap[itemInfo.maneuver]) {
+              sectionsMap[itemInfo.maneuver] = {
+                title: itemInfo.maneuver,
+                rows: []
+              };
+            }
+            
+            const rate = Math.round((event.violations / event.total) * 100);
+            let tone = '';
+            if (rate > 5) tone = 'danger';
+            else if (rate > 0) tone = 'warn';
+            else if (rate === 0) tone = 'good';
+
+            let tag = '';
+            if (tone === 'danger' || tone === 'warn') tag = '!';
+            if (tone === 'good') tag = 'good';
+
+            sectionsMap[itemInfo.maneuver].rows.push({
+              no: event.id,
+              name: itemInfo.name,
+              tag: tag,
+              tone: tone,
+              rate: rate,
+              detail: `(${event.violations}回/${event.total}回)`,
+              count: event.violations,
+              page: itemInfo.page
+            });
+          }
+        });
+        finalReportData.sections = Object.values(sectionsMap);
+        return finalReportData;
+      });
+
+      res.render('pages/report', { reports: reports });
     });
   });
 });

--- a/views/pages/report.ejs
+++ b/views/pages/report.ejs
@@ -2,122 +2,101 @@
 <html lang="ja">
 <head>
   <meta charset="utf-8" />
-  <title><%= pageTitle || "診断結果｜概要" %></title>
+  <title><%= reports[0]?.pageTitle || "診断結果｜概要" %></title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <link rel="stylesheet" href="/css/report.css" />
 </head>
 <body class="print-a4">
-  <main class="sheet">
+  <% reports.forEach(report => { %>
+    <main class="sheet">
 
-    <!-- ===== ヘッダー（青帯） ===== -->
-    <header class="topbar">
-      <h1 class="topbar__title">
-        <span>診断結果</span><span class="sep">｜</span><span>概要</span>
-      </h1>
-      <dl class="meta">
-        <div class="meta__item">
-          <dt>事業所</dt><dd><%= officeName || "矢崎事業所" %></dd>
-        </div>
-        <div class="meta__item">
-          <dt>氏名</dt><dd><%= driverName || "安全 太郎" %></dd>
-        </div>
-      </dl>
-    </header>
+      <!-- ===== ヘッダー（青帯） ===== -->
+      <header class="topbar">
+        <h1 class="topbar__title">
+          <span>診断結果</span><span class="sep">｜</span><span>概要</span>
+        </h1>
+        <dl class="meta">
+          <div class="meta__item">
+            <dt>事業所</dt><dd><%= report.officeName || "矢崎事業所" %></dd>
+          </div>
+          <div class="meta__item">
+            <dt>氏名</dt><dd><%= report.driverName || "安全 太郎" %></dd>
+          </div>
+        </dl>
+      </header>
 
-    <!-- ===== KPI（平均と順位） ===== -->
-    <section class="headline">
-      <div class="headline__label">違反疑い割合平均</div>
-      <div class="headline__value"><%= (avgViolationRatePct ?? 10.9) %>%</div>
-      <div class="headline__rank">(<%= (rank?.total ?? 10) %>人中<%= (rank?.position ?? 8) %>位)</div>
-    </section>
+      <!-- ===== KPI（平均と順位） ===== -->
+      <section class="headline">
+        <div class="headline__label">違反疑い割合平均</div>
+        <div class="headline__value"><%= (report.avgViolationRatePct ?? 10.9) %>%</div>
+        <div class="headline__rank">(<%= (report.rank?.total ?? 10) %>人中<%= (report.rank?.position ?? 8) %>位)</div>
+      </section>
 
-    <!-- ===== ハイライト3カード ===== -->
-    <section class="highlights">
-      <% const cards = highlights || [
-        {
-          kind: "danger",
-          badge: "！ 危険疑い回数が多い項目",
-          title: "左折前安全確認",
-          text: "200回左折したうち、11回の危険疑いがありました。左折時には、バイクや自転車の巻き込みをしないよう注意しましょう。"
-        },
-        {
-          kind: "warn",
-          badge: "！ 違反疑い割合が高い項目",
-          title: "右折中速度",
-          text: "200回右折したうち、50回違反（25%）の疑いがありました。右折時には左折時と比べて見通しも悪く、徐行を心がけいつでも停止できる速度で右折することが重要です。"
-        },
-        {
-          kind: "good",
-          badge: "◎ 高評価ポイント",
-          title: "一時停止",
-          text: "200回一時停止したうち違反疑いの回数は0回でした。"
-        }
-      ]; %>
-      <% cards.forEach(c => { %>
-        <article class="hl hl--<%= c.kind %>">
-          <div class="hl__band"><%= c.badge %></div>
-          <h2 class="hl__title"><%= c.title %></h2>
-          <p class="hl__text"><%= c.text %></p>
-        </article>
-      <% }) %>
-    </section>
+      <!-- ===== ハイライト3カード ===== -->
+      <section class="highlights">
+        <% const cards = report.highlights || []; %>
+        <% cards.forEach(c => { %>
+          <article class="hl hl--<%= c.kind %>">
+            <div class="hl__band"><%= c.badge %></div>
+            <h2 class="hl__title"><%= c.title %></h2>
+            <p class="hl__text"><%= c.text %></p>
+          </article>
+        <% }) %>
+      </section>
 
-
-
-    <% const groups = sections || []; %>
-    <% groups.forEach(g => { %>
-      <table class="group-table">
-        <thead>
-          <tr>
-            <th class="cell--no"><%= g.title %></th>
-            <th class="cell--name">項目</th>
-            <th class="cell--tag">指導提案</th>
-            <th class="cell--rate">違反疑い割合</th>
-            <th class="cell--count">危険疑い回数</th>
-            <th class="cell--page">詳細</th>
-          </tr>
-        </thead>
-        <tbody>
-          <% g.rows.forEach(r => { %>
-            <tr class="<%= r.tone ? 'row--' + r.tone : '' %>">
-              <td class="cell--no">
-                <% if (r.no !== "") { %>
-                  <span class="no"><%= r.no %></span>
-                <% } else { %>
-                  -
-                <% } %>
-              </td>
-              <td class="cell--name"><%= r.name %></td>
-              <td class="cell--tag"><%= r.tag || '-' %></td>
-              <td class="cell--rate">
-                <% if (r.rate !== "" && r.rate !== null && r.rate !== undefined) { %>
-                  <strong class="rate"><%= r.rate %>%</strong>
-                  <div class="detail"><%= r.detail %></div>
-                <% } else { %>
-                  -
-                <% } %>
-              </td>
-              <td class="cell--count">
-                <% if (r.count !== "" && r.count !== null && r.count !== undefined) { %>
-                  <strong><%= r.count %>回</strong>
-                <% } else { %>
-                  -
-                <% } %>
-              </td>
-              <td class="cell--page">
-                <% if (r.page) { %>
-                  <span class="btn"><%= r.page %> ▶</span>
-                <% } else { %>
-                  -
-                <% } %>
-              </td>
+      <% const groups = report.sections || []; %>
+      <% groups.forEach(g => { %>
+        <table class="group-table">
+          <thead>
+            <tr>
+              <th class="cell--no"><%= g.title %></th>
+              <th class="cell--name">項目</th>
+              <th class="cell--tag">指導提案</th>
+              <th class="cell--rate">違反疑い割合</th>
+              <th class="cell--count">危険疑い回数</th>
+              <th class="cell--page">詳細</th>
             </tr>
-          <% }) %>
-        </tbody>
-      </table>
-    <% }) %>
-
-    
-  </main>
+          </thead>
+          <tbody>
+            <% g.rows.forEach(r => { %>
+              <tr class="<%= r.tone ? 'row--' + r.tone : '' %>">
+                <td class="cell--no">
+                  <% if (r.no !== "") { %>
+                    <span class="no"><%= r.no %></span>
+                  <% } else { %>
+                    -
+                  <% } %>
+                </td>
+                <td class="cell--name"><%= r.name %></td>
+                <td class="cell--tag"><%= r.tag || '-' %></td>
+                <td class="cell--rate">
+                  <% if (r.rate !== "" && r.rate !== null && r.rate !== undefined) { %>
+                    <strong class="rate"><%= r.rate %>%</strong>
+                    <div class="detail"><%= r.detail %></div>
+                  <% } else { %>
+                    -
+                  <% } %>
+                </td>
+                <td class="cell--count">
+                  <% if (r.count !== "" && r.count !== null && r.count !== undefined) { %>
+                    <strong><%= r.count %>回</strong>
+                  <% } else { %>
+                    -
+                  <% } %>
+                </td>
+                <td class="cell--page">
+                  <% if (r.page) { %>
+                    <span class="btn"><%= r.page %> ▶</span>
+                  <% } else { %>
+                    -
+                  <% } %>
+                </td>
+              </tr>
+            <% }) %>
+          </tbody>
+        </table>
+      <% }) %>
+    </main>
+  <% }) %>
 </body>
 </html>


### PR DESCRIPTION
- `driver-data.json` を複数ドライバーを格納できる配列形式に変更。
- `server.js` と `report.ejs` を更新し、複数ドライバーのレポートをループで描画するように対応。
- 印刷時にドライバーごとに改ページされるようCSSを更新。