### PR TITLE
feat: PDFダウンロード機能とUIデザインの刷新

### DIFF
--- a/pdf-generator.js
+++ b/pdf-generator.js
@@ -1,0 +1,40 @@
+const puppeteer = require('puppeteer');
+
+async function generatePdfFromUrl(url) {
+  let browser;
+  try {
+    browser = await puppeteer.launch({
+      headless: true,
+      args: ['--no-sandbox', '--disable-setuid-sandbox'] // Important for running in many environments
+    });
+    const page = await browser.newPage();
+    
+    // Navigate to the page and wait for it to be fully loaded
+    await page.goto(url, { waitUntil: 'networkidle0' });
+    
+    // Generate the PDF
+    const pdfBuffer = await page.pdf({
+      format: 'A4',
+      printBackground: true, // Ensure CSS backgrounds are printed
+      margin: { // Match CSS @page margins
+        top: '15mm',
+        right: '12mm',
+        bottom: '15mm',
+        left: '12mm'
+      }
+    });
+    
+    return pdfBuffer;
+  } catch (error) {
+    console.error('Error generating PDF:', error);
+    throw new Error('Could not generate PDF.');
+  } finally {
+    if (browser) {
+      await browser.close();
+    }
+  }
+}
+
+module.exports = {
+  generatePdfFromUrl
+};

--- a/server.js
+++ b/server.js
@@ -2,6 +2,7 @@ const express = require('express');
 const path = require('path');
 const fs = require('fs');
 const { generateReports } = require('./report-generator.js');
+const { generatePdfFromUrl } = require('./pdf-generator.js');
 
 const app = express();
 const port = 3000;
@@ -13,12 +14,26 @@ app.set('views', path.join(__dirname, 'views'));
 // Serve static files from the "public" directory
 app.use(express.static(path.join(__dirname, 'public')));
 
-app.get(('/'), (req, res) => {
-  res.render('pages/root');
+// --- Endpoints ---
+
+// Root: Dashboard page
+app.get('/', (req, res) => {
+  const dataPath = path.join(__dirname, 'driver-data.json');
+  fs.readFile(dataPath, 'utf8', (err, dataRaw) => {
+    if (err) {
+      console.error(err);
+      return res.status(500).send('Error reading driver data');
+    }
+    const driversData = JSON.parse(dataRaw);
+    res.render('pages/report-links', {
+      reportTitle: '運転診断レポート一覧',
+      drivers: driversData
+    });
+  });
 });
 
-// Route for /report
-app.get('/report', (req, res) => {
+// HTML Preview: All drivers
+app.get('/reports/all', (req, res) => {
   const dataPath = path.join(__dirname, 'driver-data.json');
   const configPath = path.join(__dirname, 'report-config.json');
 
@@ -32,16 +47,78 @@ app.get('/report', (req, res) => {
         console.error(err);
         return res.status(500).send('Error reading report config');
       }
-
       const driversData = JSON.parse(dataRaw);
       const config = JSON.parse(configRaw);
-
       const reports = generateReports(driversData, config);
-
       res.render('pages/report', { reports: reports });
     });
   });
 });
+
+// HTML Preview: Single driver
+app.get('/reports/:driverId', (req, res) => {
+  const driverId = req.params.driverId;
+  const dataPath = path.join(__dirname, 'driver-data.json');
+  const configPath = path.join(__dirname, 'report-config.json');
+
+  fs.readFile(dataPath, 'utf8', (err, dataRaw) => {
+    if (err) {
+      console.error(err);
+      return res.status(500).send('Error reading driver data');
+    }
+    fs.readFile(configPath, 'utf8', (err, configRaw) => {
+      if (err) {
+        console.error(err);
+        return res.status(500).send('Error reading report config');
+      }
+      const driversData = JSON.parse(dataRaw);
+      const config = JSON.parse(configRaw);
+      
+      const singleDriverData = driversData.find(d => d.driverId === driverId);
+      if (!singleDriverData) {
+        return res.status(404).send('Driver not found');
+      }
+
+      const reports = generateReports([singleDriverData], config);
+      res.render('pages/report', { reports: reports });
+    });
+  });
+});
+
+// PDF Download: All drivers
+app.get('/download/all', async (req, res) => {
+  try {
+    const url = `http://localhost:${port}/reports/all`;
+    const pdfBuffer = await generatePdfFromUrl(url);
+    res.setHeader('Content-Type', 'application/pdf');
+    res.setHeader('Content-Disposition', 'attachment; filename="report-all-drivers.pdf"');
+    res.send(pdfBuffer);
+  } catch (error) {
+    res.status(500).send('Failed to generate PDF.');
+  }
+});
+
+// PDF Download: Single driver
+app.get('/download/:driverId', async (req, res) => {
+  const driverId = req.params.driverId;
+  try {
+    const url = `http://localhost:${port}/reports/${driverId}`;
+    const pdfBuffer = await generatePdfFromUrl(url);
+    res.setHeader('Content-Type', 'application/pdf');
+    res.setHeader('Content-Disposition', `attachment; filename="report-${driverId}.pdf"`);
+    res.send(pdfBuffer);
+  } catch (error) {
+    res.status(500).send('Failed to generate PDF.');
+  }
+});
+
+
+// --- Deprecated Routes ---
+// Redirect old /report to the new /reports/all
+app.get('/report', (req, res) => {
+  res.redirect('/reports/all');
+});
+
 
 // Start the server
 app.listen(port, () => {

--- a/views/pages/report-links.ejs
+++ b/views/pages/report-links.ejs
@@ -2,88 +2,198 @@
 <html lang="ja">
 <head>
   <meta charset="UTF-8">
-  <title>レポートダウンロード</title>
+  <title><%= reportTitle %></title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <style>
+    :root {
+      --bg-color: #f0f2f5;
+      --text-color: #4a5568;
+      --title-color: #1a202c;
+      --card-bg: #ffffff;
+      --border-color: #e2e8f0;
+      --shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
+      --primary-color: #2c5282;
+      --primary-hover: #2a4365;
+      --secondary-color: #4a5568;
+      --secondary-hover: #2d3748;
+    }
+
     body {
-      font-family: 'Helvetica Neue', Arial, sans-serif;
-      margin: 20px;
-      background-color: #f4f4f4;
-      color: #333;
+      font-family: 'Inter', sans-serif;
+      margin: 0;
+      background-color: var(--bg-color);
+      color: var(--text-color);
+      display: flex;
+      justify-content: center;
+      align-items: flex-start;
+      min-height: 100vh;
+      padding: 40px;
+      box-sizing: border-box;
     }
-    h1 {
-      color: #0056b3;
+
+    .container {
+      width: 100%;
+      max-width: 900px;
     }
+
+    header {
+      margin-bottom: 60px;
+      text-align: center;
+      position: relative;
+      padding-bottom: 20px;
+    }
+
+    header::after {
+      content: '';
+      position: absolute;
+      bottom: 0;
+      left: 50%;
+      transform: translateX(-50%);
+      width: 80px;
+      height: 4px;
+      background: linear-gradient(90deg, var(--primary-color), var(--primary-hover));
+      border-radius: 2px;
+    }
+
+    header h1 {
+      font-size: 2.5rem;
+      font-weight: 700;
+      margin: 0 0 12px 0;
+      background: linear-gradient(90deg, var(--primary-hover), var(--primary-color));
+      -webkit-background-clip: text;
+      -webkit-text-fill-color: transparent;
+      background-clip: text;
+      text-fill-color: transparent;
+    }
+
+    .subtitle {
+      font-size: 1.1rem;
+      color: var(--text-color);
+      margin: 0;
+    }
+
+    .section {
+      background: var(--card-bg);
+      border-radius: 12px;
+      padding: 32px;
+      box-shadow: var(--shadow);
+      margin-bottom: 30px;
+    }
+
+    .section h2 {
+      font-size: 1.5rem;
+      font-weight: 600;
+      color: var(--title-color);
+      margin-top: 0;
+      margin-bottom: 24px;
+      padding-bottom: 16px;
+      border-bottom: 1px solid var(--border-color);
+    }
+    
     ul {
       list-style: none;
       padding: 0;
     }
+
     li {
-      margin-bottom: 15px;
-      background-color: #fff;
-      padding: 15px;
-      border-radius: 8px;
-      box-shadow: 0 2px 5px rgba(0,0,0,0.1);
       display: flex;
       align-items: center;
       justify-content: space-between;
       flex-wrap: wrap;
+      padding: 20px 0;
+      border-bottom: 1px solid var(--border-color);
     }
+
+    li:last-child {
+      border-bottom: none;
+      padding-bottom: 0;
+    }
+    li:first-child {
+      padding-top: 0;
+    }
+
     li span {
-      font-size: 1.1em;
-      font-weight: bold;
-      color: #333;
+      font-size: 1.1rem;
+      font-weight: 500;
+      color: var(--title-color);
       margin-right: 20px;
     }
+
+    .button-group {
+      display: flex;
+      gap: 12px;
+    }
+
     .button-group a {
       display: inline-block;
-      padding: 10px 15px;
+      padding: 10px 20px;
       color: white;
       text-decoration: none;
-      border-radius: 5px;
-      transition: background-color 0.3s ease;
-      margin-left: 10px; /* Space between buttons */
+      border-radius: 8px;
+      transition: all 0.2s ease-in-out;
+      font-weight: 500;
+      border: 1px solid transparent;
     }
+
+    .button-group a:hover {
+      transform: translateY(-2px);
+      box-shadow: 0 7px 14px rgba(50, 50, 93, 0.1), 0 3px 6px rgba(0, 0, 0, 0.08);
+    }
+
     .button-group a.download-pdf {
-      background-color: #28a745; /* Green for download */
+      background-color: var(--primary-color);
     }
     .button-group a.download-pdf:hover {
-      background-color: #218838;
+      background-color: var(--primary-hover);
     }
+
     .button-group a.view-html {
-      background-color: #007BFF; /* Blue for view HTML */
+      background-color: transparent;
+      color: var(--secondary-color);
+      border-color: var(--border-color);
     }
     .button-group a.view-html:hover {
-      background-color: #0056b3;
-    }
-    .all-stores-zip {
-      margin-top: 30px;
-      text-align: center;
-    }
-    .all-stores-zip a {
-      background-color: #6c757d;
-    }
-    .all-stores-zip a:hover {
-      background-color: #5a6268;
+      background-color: var(--secondary-color);
+      color: white;
     }
   </style>
 </head>
 <body>
-  <h1><%= salesData.reportTitle %> - レポートオプション</h1>
-  <p>以下のオプションから、各店舗のレポートを選択してください。</p>
-  <ul>
-    <% salesData.stores.forEach(function(store, index) { %>
-      <li>
-        <span><%= store.name %></span>
-        <div class="button-group">
-          <a href="/download-pdf-puppeteer/<%= index %>" class="download-pdf" target="_blank">PDFをダウンロード</a>
-          <a href="/report-store/<%= index %>" class="view-html" target="_blank">HTMLを表示</a>
-        </div>
-      </li>
-    <% }); %>
-  </ul>
-  <div class="all-stores-zip">
-    <p>または、</p>
-    <a href="/report">全店舗のレポートをZIPでダウンロード</a>
+  <div class="container">
+    <header>
+      <h1><%= reportTitle %></h1>
+      <p class="subtitle">表示したいレポートの形式（PDFまたはHTML）を選択してください。</p>
+    </header>
+    
+    <div class="section">
+      <h2>全体のレポート</h2>
+      <ul>
+        <li>
+          <span>全ドライバーのレポート</span>
+          <div class="button-group">
+            <a href="/download/all" class="download-pdf">PDFダウンロード</a>
+            <a href="/reports/all" class="view-html" target="_blank">HTMLプレビュー</a>
+          </div>
+        </li>
+      </ul>
+    </div>
+
+    <div class="section">
+      <h2>個人のレポート</h2>
+      <ul>
+        <% drivers.forEach(function(driver) { %>
+          <li>
+            <span><%= driver.driverName %> (<%= driver.officeName %>)</span>
+            <div class="button-group">
+              <a href="/download/<%= driver.driverId %>" class="download-pdf">PDFダウンロード</a>
+              <a href="/reports/<%= driver.driverId %>" class="view-html" target="_blank">HTMLプレビュー</a>
+            </div>
+          </li>
+        <% }); %>
+      </ul>
+    </div>
   </div>
 </body>
 </html>


### PR DESCRIPTION
- 個人および全ドライバーレポートのPDFダウンロード機能を追加 (`puppeteer` を利用)。
- `/`, `/reports/:id`, `/download/:id` などのエンドポイントを実装。
- `pdf-generator.js` を追加し、PDF生成ロジックを分離。
- ダッシュボードUIをモダンで高級感のあるデザインに刷新し、タイポグラフィ、カラーパレット、レイアウトを改善。