### PR TITLE
feat: レポートフッター枠と動画再生ボタンのデザイン調整

### DIFF
--- a/public/css/report.css
+++ b/public/css/report.css
@@ -91,6 +91,65 @@ body.print-a4 {
 .group-table + .group-table {
   margin-top: 3mm;
 }
+
+.summary-frame {
+  border: 1px solid var(--line);
+  padding: 3mm 10mm;
+  margin-top: 10mm;
+  border-radius: 8px;
+  min-height: 10mm;
+  background-color: var(--panel);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  box-shadow: 0 2px 5px rgba(0,0,0,0.05);
+}
+
+.summary-column {
+  flex: 1;
+  padding: 0 5mm;
+}
+
+.left-column {
+  text-align: left;
+  font-weight: 600;
+  color: var(--ink-900);
+  font-size: 10.5pt;
+}
+
+.right-column {
+  text-align: right;
+}
+
+.play-button-mock {
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  width: 12mm;
+  height: 8mm;
+  background-color: var(--red-600);
+  color: #fff;
+  padding: 0;
+  border-radius: 3mm;
+  font-size: 10pt;
+  font-weight: 600;
+  cursor: pointer;
+  box-shadow: none;
+  transition: all 0.2s ease-in-out;
+  text-decoration: none;
+  overflow: hidden;
+}
+
+.play-button-mock:hover {
+  transform: scale(1.05);
+  box-shadow: none;
+}
+
+.play-icon {
+  font-size: 10pt;
+  line-height: 1;
+  transform: translateX(0.5mm);
+}
 .group-table thead th {
   background: #f6f9ff; /* Reverted color */
   padding: 2.5mm 4mm;

--- a/views/pages/report-links.ejs
+++ b/views/pages/report-links.ejs
@@ -187,7 +187,7 @@
           <li>
             <span><%= driver.driverName %> (<%= driver.officeName %>)</span>
             <div class="button-group">
-              <a href="/download/<%= driver.driverId %>" class="download-pdf">PDFダウンロード</a>
+              <a href="/download/<%= driver.driverId %>" class="download-pdf" target="_blank">PDFダウンロード</a>
               <a href="/reports/<%= driver.driverId %>" class="view-html" target="_blank">HTMLプレビュー</a>
             </div>
           </li>

--- a/views/pages/report.ejs
+++ b/views/pages/report.ejs
@@ -99,6 +99,16 @@
           </tbody>
         </table>
       <% }) %>
+      <div class="summary-frame">
+        <div class="summary-column left-column">
+          <p>BOX動画再生 確認用</p>
+        </div>
+        <div class="summary-column right-column">
+          <a href="https://app.box.com/file/1962444890135?s=g215xtzrz2unrh1cvn4595xf079dm8p0" target="_blank" class="play-button-mock">
+            <span class="play-icon">▶</span>
+          </a>
+        </div>
+      </div>
     </main>
   <% }) %>
 </body>


### PR DESCRIPTION
- フッター上の枠 (`.summary-frame`) の縦幅を調整し、背景色を白に変更。
- 「BOX動画再生 確認用」の文字色を黒に変更。
- 再生ボタンのデザインをYouTubeアイコン風に調整し、背景色を`--red-600`に設定。
- 再生ボタンから「再生」の文言を削除。