### PR TITLE
fix: Render環境でのPDFダウンロード問題の修正

### DIFF
--- a/pdf-generator.js
+++ b/pdf-generator.js
@@ -1,11 +1,23 @@
-const puppeteer = require('puppeteer');
+const puppeteer = require('puppeteer'); // puppeteer に戻す
 
 async function generatePdfFromUrl(url) {
   let browser;
   try {
+    // 環境変数 CHROMIUM_PATH が設定されていればそれを使用し、なければ Puppeteer に任せる
+    const executablePath = process.env.CHROMIUM_PATH || undefined;
+
     browser = await puppeteer.launch({
-      headless: true,
-      args: ['--no-sandbox', '--disable-setuid-sandbox'] // Important for running in many environments
+      executablePath: executablePath,
+      headless: true, // Render環境では 'new' または 'true' が推奨される場合がある
+      args: [
+        '--no-sandbox',
+        '--disable-setuid-sandbox',
+        '--disable-dev-shm-usage', // Renderのようなコンテナ環境でメモリ不足を防ぐ
+        '--disable-gpu', // GPUアクセラレーションを無効化
+        '--no-zygote', // プロセス起動を高速化
+        '--single-process' // シングルプロセスモードで実行
+      ],
+      ignoreHTTPSErrors: true,
     });
     const page = await browser.newPage();
     


### PR DESCRIPTION
- puppeteer-coreと@sparticuz/chromiumの使用を中止し、puppeteerに戻す。
- Render環境でのChromiumパスを環境変数CHROMIUM_PATHで指定できるように変更。
- Render環境で推奨されるPuppeteer起動オプションを追加。